### PR TITLE
Corrects the Getting Started URI and the GitHub Issue URI

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -77,7 +77,7 @@ If you have any questions, concerns, or need assistance, you can reach out to th
 
 Please feel free to contact any of the authors if you have any inquiries related to the PHYLOViZ Web Platform. They will be happy to assist you.
 
-If you encounter any bugs, have feature requests, or would like to report any issues, please visit the [Issues](https://github.com/bodybuilders-team/phyloviz-web-platform/issues) section 
+If you encounter any bugs, have feature requests, or would like to report any issues, please visit the [Issues](https://github.com/phyloviz/phyloviz-web-platform/issues) section 
 on GitHub and create a new issue. 
 Your feedback and contributions are valuable to us, and we appreciate your help in improving the platform.
 

--- a/src/frontend/src/Pages/WebUiUris.ts
+++ b/src/frontend/src/Pages/WebUiUris.ts
@@ -12,7 +12,7 @@ export namespace WebUiUris {
     export const NEW_PROJECT = "/new-project"
     export const OPEN_PROJECT = "/open-project"
 
-    export const GET_STARTED = "https://github.com/bodybuilders-team/phyloviz-web-platform/wiki/getting-started"
+    export const GET_STARTED = "https://github.com/phyloviz/phyloviz-web-platform/wiki/getting-started"
 
     export const PROJECT = "/projects/:projectId"
     export const EDIT_PROJECT = `${PROJECT}/edit`


### PR DESCRIPTION
Both URIs direct to the bodybuilders-team organization, which does not have a public phyloviz-web-platform repository.
I changed both of them to now direct to the phyloviz organization.